### PR TITLE
Add CI tests for Python 3.12 and pytest 8

### DIFF
--- a/.github/workflows/pythontests.yml
+++ b/.github/workflows/pythontests.yml
@@ -40,10 +40,14 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: [3.7, 3.8, 3.9, "3.10", "3.11", "pypy-3.7"]
-        exclude:
-          - os: windows-latest
-            python-version: pypy3
+        python-version: [3.7, 3.8, 3.9, "3.10", "3.11", "3.12"]
+        include:
+          - python-version: "pypy-3.7"
+            os: ubuntu-latest
+          - python-version: "pypy-3.9"
+            os: ubuntu-latest
+          - python-version: "pypy-3.10"
+            os: ubuntu-latest
     env:
       OS: ${{ matrix.os }}
     steps:
@@ -68,7 +72,7 @@ jobs:
         python -m pip install pytest pytest-cov pytest-randomly tox
     - name: Run tests
       run: |
-        TOX_PYTHON_VERSION=$(if [ ${{ matrix.python-version }} = pypy-3.7 ]; then echo "pypy3"; else echo py${{ matrix.python-version }} | tr -d .; fi)
+        TOX_PYTHON_VERSION=$(if [[ ${{ matrix.python-version }} == pypy* ]]; then echo ${{ matrix.python-version }} | tr -d .-; else echo py${{ matrix.python-version }} | tr -d .-; fi)
         COV_CMD=$(if [ ${{ matrix.python-version }} = 3.10 ]; then echo "--cov=find_dependencies --cov-report=xml"; else echo ; fi) tox -e $(tox -l | grep $TOX_PYTHON_VERSION | paste -sd "," -)
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v4

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         'Programming Language :: Python :: 3 :: Only',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',

--- a/tests/test_find_dependencies.py
+++ b/tests/test_find_dependencies.py
@@ -103,10 +103,10 @@ def test_single_dependency_collect_only(test_path):
     assert int(result.ret) == 0
     result.stdout.fnmatch_lines([
         "collected 3 items",
-        "<Module test_one.py>",
-        "  <Function test_a>",
-        "  <Function test_b>",
-        "  <Function test_c>"
+        "*<Module test_one.py>",
+        "*  <Function test_a>",
+        "*  <Function test_b>",
+        "*  <Function test_c>"
     ])
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,22 +1,22 @@
 # For more information about tox, see https://tox.readthedocs.io/en/latest/
 [tox]
 envlist =
-    {py37,py38,py39,pypy3}-pytest{43,50,54,60,61,62,70,72}
-    {py310,py311}-pytest{624,70,72}
+    {py37,pypy37}-pytest{50,54,60,62,624,70,74}
+    {py38,py39,pypy39}-pytest{50,54,60,62,624,70,74,80}
+    {py310,py311,py312,pypy310}-pytest{624,70,74,80}
 
 [testenv]
 deps =
-    pytest43: pytest>=4.3,<4.4
     pytest50: pytest>=5.0,<5.1
     pytest54: pytest>=5.4,<6.0
     pytest60: pytest>=6.0,<6.1
-    pytest61: pytest>=6.1,<6.2
     pytest62: pytest>=6.2,<6.3
     pytest624: pytest>=6.2.4,<6.3
     pytest70: pytest>=7.0,<7.1
-    pytest72: pytest>=7.2,<7.3
-    pytest{43,50,54}: pytest-xdist<2.0.0
-    pytest{60,61,62,624,70,72}: pytest-xdist
+    pytest74: pytest>=7.3,<8.0
+    pytest80: pytest==8.0.1
+    pytest{50,54}: pytest-xdist<2.0.0
+    pytest{60,62,624,70,74,80}: pytest-xdist
     pytest-cov
     pytest-randomly
 


### PR DESCRIPTION
- adapt tests for pytest 8
- fixes #13